### PR TITLE
Allow real discord gifts

### DIFF
--- a/src/logic/SpamMeta.ts
+++ b/src/logic/SpamMeta.ts
@@ -25,6 +25,9 @@ export class SpamMeta {
   }
 
   static isSpam(content: string): boolean {
+    if (content.startsWith("https://discord.gift")) {
+      return false;
+    }
     return this._spamLinks.some((link) => {
       return RegExp(link, "gm").test(content);
     });


### PR DESCRIPTION
Real discord gifts appear in the domain "discord.gift",. this should be a hard-coded exception to allow it